### PR TITLE
Typo in 1.1.3.2 (Machine learning engineer vs. Software engineer)

### DIFF
--- a/contents/1.1.3.2-machine-learning-engineer-vs.-software-engineer.md
+++ b/contents/1.1.3.2-machine-learning-engineer-vs.-software-engineer.md
@@ -1,6 +1,6 @@
 #### 1.1.3.2 Machine learning engineer vs. software engineer
 
-ML engineering is considered a subfield of software engineering. In most organizations, the hiring process for MLEs is spun out of their existing SWE hiring process. Some organizations might swap out a few SWE questions for ML-specific questions. Some just add an interview specially focused on ML on top of their existing interview process for ML, making their MLE process a bit longer than their SWE process.
+ML engineering is considered a subfield of software engineering. In most organizations, the hiring process for MLEs is spun out of their existing SWE hiring process. Some organizations might swap out a few SWE questions for ML-specific questions. Some just add an interview specially focused on ML on top of their existing interview process for SWE, making their MLE process a bit longer than their SWE process.
 
 Overall, MLE candidates are expected to know how to code and be familiar with software engineering tools. Many traditional SWE tools can be used to develop and deploy ML applications.
 


### PR DESCRIPTION

Hi Chip, this is a really great book and loving it so far! 👍 (Just helping fix typos here and there)
Change 

> Some just add an interview specially focused on ML on top of their existing interview process for ~~**ML**~~

to

> Some just add an interview specially focused on ML on top of their existing interview process for **SWE**

Also closes #12 