### PR TITLE
bugfix: replace dead link to statistics course

### DIFF
--- a/contents/4.3.1-courses.md
+++ b/contents/4.3.1-courses.md
@@ -2,9 +2,9 @@
 
 The courses are listed in the order they should be taken. It was combined in August 2019, so some of the links might have become outdated, but the curriculum can still be useful to have a sense of what areas of knowledge you should acquire and find other ways to acquire them, e.g. other courses or books[^51].
 
-**1. Probability and Statistics by Stanford Online**
+**1. Introduction to Statistics by Stanford (Coursera)**
 
-[See course materials](https://online.stanford.edu/courses/gse-yprobstat-probability-and-statistics) (free online course)
+[See course materials](https://www.coursera.org/learn/stanford-statistics) (free online course)
 
 This self-paced course covers basic concepts in probability and statistics spanning over four fundamental aspects of machine learning: exploratory data analysis, producing data, probability, and inference.
 


### PR DESCRIPTION
Replace dead link to Stanford's Probability & Statistics course with a Coursera version by Stanford, covering the same materials.

Related https://github.com/chiphuyen/ml-interviews-book/issues/35