### PR TITLE
Replaced dead link to "the curse of big data"

### DIFF
--- a/contents/5.2.2-stats.md
+++ b/contents/5.2.2-stats.md
@@ -41,7 +41,7 @@ From [xkcd](https://xkcd.com/552/). To distract yourself from interviewing stres
     1. [E] What’s the probability that this happens by chance?
     1. [M] How to avoid this kind of accidental patterns?
     
-    **Hint**: Check out [the curse of big data](https://www.analyticbridge.datasciencecentral.com/profiles/blogs/the-curse-of-big-data).
+    **Hint**: Check out [the curse of big data](https://web.archive.org/web/20210926153005/https://www.analyticbridge.datasciencecentral.com/profiles/blogs/the-curse-of-big-data).
 18. [H] How are sufficient statistics and Information Bottleneck Principle used in machine learning?
 
 ---


### PR DESCRIPTION
Replaced dead link to "the curse of big data" article with an archived copy from The Wayback Machine